### PR TITLE
Remove force_retain feature

### DIFF
--- a/src/tracely/clean_trace.py
+++ b/src/tracely/clean_trace.py
@@ -250,7 +250,7 @@ class CleanTrace():
             if distance is None:
                 continue
 
-            if (distance < min_dist_bw_consecutive_pings) and not (row["force_retain"]):
+            if distance < min_dist_bw_consecutive_pings:
                 mask[i] = True
                 continue
 

--- a/src/tracely/constants.py
+++ b/src/tracely/constants.py
@@ -48,7 +48,6 @@ OPTIONAL_ITEMS_IN_A_PING = {
     "ping_id": None,
     "error_radius": None,
     "event_type": None,
-    "force_retain": False,
     "metadata": {},
 }
 
@@ -111,7 +110,6 @@ CLEAN_TRACE_COLUMNS_WITHOUT_METADATA = [
     "timestamp",
     "error_radius",
     "event_type",
-    "force_retain",
 
     "cleaned_latitude",
     "cleaned_longitude",

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -256,15 +256,6 @@ def test_invalid_error_radius_type_in_a_ping():
         trace_data_obj = CleanTrace(payload)
 
 
-def test_invalid_force_retain_type_in_a_ping():
-    """Test data type of "force_retain" in a ping in "trace"."""
-
-    payload = load_trace_payload("dummy_trace_input_payload")
-    payload["trace"][0]["force_retain"] = "invalid"
-    expected_error_msg = re.escape('("force_retain must be of type Bool but found <class \'str\'>", 4002)')
-
-    with pytest.raises(ValidationException, match=expected_error_msg) as e:
-        trace_data_obj = CleanTrace(payload)
 
 
 def test_invalid_event_type_type_in_a_ping():
@@ -326,7 +317,6 @@ def test_missing_optional_keys_in_a_ping():
         if ping["ping_id"] == ping_id:
             assert ping["error_radius"] == None
             assert ping["event_type"] == None
-            assert ping["force_retain"] == False
             assert ping["metadata"] == {}
 
 


### PR DESCRIPTION
This change removes the force_retain feature from the tracely library. The feature allowed users to prevent specific pings from being dropped during trace cleaning. This commit removes the code related to this feature, including its definition in the constants file and the checks in the remove_nearby_pings function. The tests have been updated to reflect this change.