### PR TITLE
Fix broken install on clean machines: pin setuptools, require compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Note: Apart from validation, **vehicle_type** and **vehicle_speed** information 
 
 
 # Installing Tracely
+   Tracely depends on `infostop`, which compiles a small C++ extension (via `infomap`) during install.
+   A C++ compiler must be available on your system beforehand — `install_tracely.sh` checks for one and
+   prints the install command for your OS if it's missing.
+
    Create an environment with python 3.11 and activate the python environment and run following commands. Then you can use the [usage example](#usage) directly.
 
    ```python

--- a/install_tracely.sh
+++ b/install_tracely.sh
@@ -13,16 +13,40 @@ if [ "$PYTHON_VERSION" != "True" ]; then
   exit 1
 fi
 
+# Ensure a C++ compiler is available (needed to build tracely's infostop/infomap dependency)
+if ! command -v g++ >/dev/null 2>&1; then
+  echo "Error: A C++ compiler (g++) is required to build tracely's dependencies but was not found."
+  echo ""
+  echo "Install it for your OS, then re-run this script:"
+  echo ""
+  echo "  Linux (Debian/Ubuntu):"
+  echo "    sudo apt-get update && sudo apt-get install -y build-essential cmake g++ gcc"
+  echo ""
+  echo "  macOS:"
+  echo "    xcode-select --install"
+  echo ""
+  echo "  Windows (in a Developer Command Prompt / PowerShell, using winget):"
+  echo "    winget install --id Kitware.CMake -e"
+  echo "    winget install --id Microsoft.VisualStudio.2022.BuildTools -e --override \"--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended\""
+  echo ""
+  exit 1
+fi
+
 # Install necessary build tools
+# setuptools is pinned below 81 because tracely's infostop -> infomap==1.0.6 dependency
+# still imports pkg_resources in its setup.py, which setuptools>=81 no longer ships.
 echo "Installing build tools..."
-python3 -m pip install --upgrade pip setuptools wheel twine build
+python3 -m pip install --upgrade pip
+python3 -m pip install "setuptools<81" wheel twine build pybind11
 
 # Build the package
 echo "Building the package..."
 python3 -m build --wheel --sdist .
 
 # Install the package
+# --no-build-isolation is required so infomap's build uses the setuptools<81 pinned
+# above instead of pip fetching the latest setuptools into an isolated build env.
 echo "Installing the package..."
-python3 -m pip install dist/tracely-1.0.0-py3-none-any.whl --force-reinstall
+python3 -m pip install --no-build-isolation dist/tracely-1.0.0-py3-none-any.whl --force-reinstall
 
 echo "Installation complete!"


### PR DESCRIPTION
tracely's infostop -> infomap==1.0.6 dependency has no Linux/modern-macOS wheel and always compiles from source, but its legacy setup.py imports pkg_resources, which setuptools>=81 no longer ships. pip's build isolation always grabs the latest setuptools for that build regardless of what's pinned outside, so the install failed on any clean machine.

install_tracely.sh now checks for a C++ compiler upfront (with copy-paste install commands per OS if missing), pins setuptools<81, and installs with --no-build-isolation so infomap's build actually uses that pinned version. Verified end-to-end in a fresh conda env (starting from setuptools 83.0.0) by running both example scripts successfully, including the one that exercises the infostop/infomap path.