### PR TITLE
Fix crash and validation gap on single-ping traces, and a divide-by-z…

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ Additionally, we have also provided a helper script `install_osrm.sh` using whic
   >>> sudo docker stop northern_india_osrm
   ```
 
+  `map_match_trace` and `interpolate_trace` default to an OSRM server at `http://127.0.0.1:5000`. If your OSRM
+  server runs at a different address (e.g. the "northern_india_osrm" container above, on port 7000), you can
+  either pass `osrm_url` explicitly to those methods, or set an `OSRM_URL` environment variable/`.env` file
+  (in the directory you run your script from) once instead of passing it every call:
+
+  ```
+  # .env
+  OSRM_URL=http://localhost:7000
+  ```
+
 
 # Usage
   * User can generate trace payload from a CSV file, create CleanTrace object and apply its methods. Example usage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,6 @@ dependencies = [
     "pandas==2.0.3",
     "polyline==2.0.2",
     "pytest==8.3.2",
+    "python-dotenv==1.2.2",
     "requests==2.32.3"
 ]

--- a/src/tracely/clean_trace.py
+++ b/src/tracely/clean_trace.py
@@ -435,7 +435,7 @@ class CleanTrace():
                                time_taken=(time.time() - start_time))
 
     def map_match_trace(self,
-                     osrm_url="http://127.0.0.1:5000/match/v1/driving/",
+                     osrm_url=constants.DEFAULT_OSRM_URL + "/match/v1/driving/",
                      ping_batch_size=5,
                      map_matching_radius=20,
                      avg_snap_distance=12,
@@ -448,8 +448,9 @@ class CleanTrace():
 
         Args:
             osrm_url (str, optional): The URL of the OSRM server for map matching.
-                                      Defaults to "http://127.0.0.1:5000/match/v1/driving/", which expects the OSRM server
-                                      to be running locally on port 5000.
+                                      Defaults to "<OSRM_URL>/match/v1/driving/", where OSRM_URL is read from an OSRM_URL
+                                      environment variable or a .env file in the current working directory, or
+                                      "http://127.0.0.1:5000" if neither is set.
             ping_batch_size (int, optional): The size of each segment for map matching pings. Defaults to 5.
             map_matching_radius (int, float, optional): The radius in meters for map matching. A location is map matched only 
                                                         if there is a road within the map matching radius. Defaults to 20 meters.
@@ -517,7 +518,7 @@ class CleanTrace():
             time_taken=(time.time() - start_time))
         
     def interpolate_trace(self,
-                          osrm_url="http://127.0.0.1:5000/route/v1/driving/",
+                          osrm_url=constants.DEFAULT_OSRM_URL + "/route/v1/driving/",
                           min_dist_from_prev_ping=10,
                           max_dist_from_prev_ping=250):
         """
@@ -527,7 +528,9 @@ class CleanTrace():
 
         Args:
             osrm_url (str, optional): A URL specifying the endpoint for accessing the OSRM route service.
-                                      Defaults to "http://127.0.0.1:5000/route/v1/driving/", which expects the OSRM server to be running locally on port 5000.
+                                      Defaults to "<OSRM_URL>/route/v1/driving/", where OSRM_URL is read from an OSRM_URL
+                                      environment variable or a .env file in the current working directory, or
+                                      "http://127.0.0.1:5000" if neither is set.
             min_dist_from_prev_ping (int, optional): Minimum distance in meters required between consecutive trace pings for interpolation. Defaults to 20 meters.
             max_dist_from_prev_ping (int, optional): Maximum distance in meters allowed between consecutive trace pings for interpolation. Defaults to 200 meters.
         
@@ -638,7 +641,8 @@ class CleanTrace():
                     prev_lat, prev_lng, prev_interpolated_ping_time = new_ping_lat, new_ping_lng, interpolated_ping_time
                     interpolated_pings.append(new_ping)
 
-        interpolated_pings.append(trace_data[i])
+        if trace_data:
+            interpolated_pings.append(trace_data[-1])
         interpolation_result = pd.DataFrame(interpolated_pings)
 
         self.trace_df = interpolation_result

--- a/src/tracely/constants.py
+++ b/src/tracely/constants.py
@@ -1,10 +1,20 @@
 import os
 import datetime
+from dotenv import load_dotenv
 
 ########################
 # Define path to tracely
 ########################
 BASE_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "")
+
+
+###############################################################
+# Load .env from the current working directory, if present, so
+# users can override defaults (e.g. OSRM_URL) without editing code.
+###############################################################
+load_dotenv()
+
+DEFAULT_OSRM_URL = os.environ.get("OSRM_URL", "http://127.0.0.1:5000")
 
 
 ##############################

--- a/src/tracely/utils/data_validation_utils.py
+++ b/src/tracely/utils/data_validation_utils.py
@@ -541,7 +541,7 @@ class DataValidationUtils:
             if "ping_id" in ping_dict:
                 ping_ids.append(ping_dict["ping_id"])
 
-            if isinstance(ping_dict["latitude"], (int, float)) and isinstance(ping_dict["latitude"], (int, float)):
+            if isinstance(ping_dict["latitude"], (int, float)) and isinstance(ping_dict["longitude"], (int, float)):
                 at_least_one_ping_with_not_null_coord = True
 
         if not at_least_one_ping_with_not_null_coord:

--- a/src/tracely/utils/plotting_utils.py
+++ b/src/tracely/utils/plotting_utils.py
@@ -51,7 +51,7 @@ def plot_raw_trace_from_trace_output(trace: list,
 
     # Dividing the trace into 10 segments, each containing 10% of trace.
     n = len(trace_df)
-    segment_size = n // 10
+    segment_size = max(n // 10, 1)  # avoid ZeroDivisionError/warning for traces with fewer than 10 pings
 
     # Create the "trace_segment" column
     trace_df["trace_segment"] = ((np.arange(n) // segment_size) + 1) * 10
@@ -136,7 +136,7 @@ def plot_clean_trace_from_trace_output(trace,
 
     # Dividing the trace into 10 segments, each containing 10% of trace.
     n = len(trace_df)
-    segment_size = n // 10
+    segment_size = max(n // 10, 1)  # avoid ZeroDivisionError/warning for traces with fewer than 10 pings
 
     # Create the "trace_segment" column
     trace_df["trace_segment"] = ((np.arange(n) // segment_size) + 1) * 10
@@ -369,7 +369,7 @@ def plot_cleaning_comparison_map_bw_two_traces(trace_before_operation,
 
     # Dividing the trace into 10 segments, each containing 10% of trace.
     n = len(trace_df)
-    segment_size = n // 10
+    segment_size = max(n // 10, 1)  # avoid ZeroDivisionError/warning for traces with fewer than 10 pings
 
     # Create the "trace_segment" column
     trace_df["trace_segment"] = ((np.arange(n) // segment_size) + 1) * 10
@@ -536,7 +536,7 @@ def plot_stop_comparison_map(left_hand_trace,
 
     # Dividing the trace into 10 segments, each containing 10% of trace.
     n = len(trace_df)
-    segment_size = n // 10
+    segment_size = max(n // 10, 1)  # avoid ZeroDivisionError/warning for traces with fewer than 10 pings
 
     # Create the "trace_segment" column
     trace_df["trace_segment"] = ((np.arange(n) // segment_size) + 1) * 10

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,5 +1,6 @@
 import re
 import os
+import warnings
 import pytest
 import folium
 import tempfile
@@ -88,7 +89,37 @@ def test_trace_key_with_only_null_lat_lng():
 
     # Set coordinates of all pings as None
     for ping in payload["trace"]:
-        ping["latitude"], ping["latitude"] = None, None
+        ping["latitude"], ping["longitude"] = None, None
+
+    expected_error_msg = re.escape("('Trace should have at least one ping with non null latitude and longitude', 4003)")
+
+    with pytest.raises(ValidationException, match=expected_error_msg) as e:
+        trace_data_obj = CleanTrace(payload)
+
+
+def test_trace_key_with_only_null_latitude():
+    """Test "trace" where every ping has a null latitude but a non null longitude."""
+
+    payload = load_trace_payload("dummy_trace_input_payload")
+    payload["trace"] = payload["trace"][:100]
+
+    for ping in payload["trace"]:
+        ping["latitude"] = None
+
+    expected_error_msg = re.escape("('Trace should have at least one ping with non null latitude and longitude', 4003)")
+
+    with pytest.raises(ValidationException, match=expected_error_msg) as e:
+        trace_data_obj = CleanTrace(payload)
+
+
+def test_trace_key_with_only_null_longitude():
+    """Test "trace" where every ping has a null longitude but a non null latitude."""
+
+    payload = load_trace_payload("dummy_trace_input_payload")
+    payload["trace"] = payload["trace"][:100]
+
+    for ping in payload["trace"]:
+        ping["longitude"] = None
 
     expected_error_msg = re.escape("('Trace should have at least one ping with non null latitude and longitude', 4003)")
 
@@ -812,6 +843,24 @@ def test_interpolate_trace():
     assert clean_output["distance_summary"]["percent_reduction_in_dist"] >= 0
 
 
+def test_interpolate_trace_single_ping():
+    """Test interpolate_trace on a trace with just one ping. Nothing can be interpolated between a
+    single ping and itself, so the ping should be returned unchanged rather than raising an error."""
+
+    payload = load_trace_payload("dummy_trace_input_payload")
+    payload["trace"] = payload["trace"][:1]
+
+    trace_data_obj = CleanTrace(payload)
+
+    trace_data_obj.map_match_trace()
+    trace_data_obj.interpolate_trace()
+
+    clean_output = trace_data_obj.get_trace_cleaning_output()
+
+    assert len(clean_output["cleaned_trace"]) == 1
+    assert clean_output["cleaned_trace"][0]["update_status"] in ("unchanged", "updated")
+
+
 def test_interpolate_trace_flag_consistency():
     """Test that interpolated points are not updated by map matching function."""
 
@@ -962,6 +1011,34 @@ def test_plot_cleaning_comparison_map():
 
     assert isinstance(trace_map_1, folium.plugins.DualMap)
     assert isinstance(trace_map_2, folium.plugins.DualMap)
+
+
+def test_plotting_single_ping_trace_no_warnings():
+    """Test that plotting functions do not raise a divide-by-zero warning (or fail) for traces
+    with fewer than 10 pings, since trace segmentation for plotting divides the trace into
+    10 buckets of size (num_pings // 10)."""
+
+    payload = load_trace_payload("dummy_trace_input_payload")
+    payload["trace"] = payload["trace"][:1]
+
+    trace_data_obj = CleanTrace(payload)
+    trace_data_obj.add_stop_events_info()
+
+    raw_output = trace_data_obj.get_trace_cleaning_output()
+    raw_trace = raw_output["cleaned_trace"]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+
+        raw_map = trace_data_obj.plot_raw_trace()
+        clean_map = trace_data_obj.plot_clean_trace()
+        comparison_map = trace_data_obj.plot_cleaning_comparison_map(raw_trace, raw_trace)
+        stop_map = trace_data_obj.plot_raw_vs_stop_comparison_map()
+
+    assert isinstance(raw_map, folium.Map)
+    assert isinstance(clean_map, folium.Map)
+    assert isinstance(comparison_map, folium.plugins.DualMap)
+    assert isinstance(stop_map, folium.plugins.DualMap)
 
 
 ########################


### PR DESCRIPTION
…ero warning

- interpolate_trace raised UnboundLocalError on a 1-ping trace, since its loop over range(1, len(trace_data)) never executes and left the post-loop reference to `i` unbound. A single ping has nothing to interpolate against, so it is now returned unchanged.
- validate_all_pings checked ping_dict["latitude"] twice instead of latitude and longitude, so a trace where every ping had a valid latitude but a null longitude silently passed validation instead of raising the intended "no ping with non-null coordinates" error. The existing regression test for this had the identical copy-paste typo (nulled latitude twice, never touched longitude) and so wasn't actually exercising the null-longitude case; fixed and split into latitude-only-null and longitude-only-null tests.
- plotting_utils divided a trace into `len(trace) // 10` segments in four places; for any trace under 10 pings this is a divide-by-zero, raising a RuntimeWarning on every plot call. Fixed with a minimum segment size of 1.

Also makes the OSRM_URL used by map_match_trace/interpolate_trace configurable via an OSRM_URL environment variable or a .env file in the caller's working directory (via python-dotenv), instead of only the hardcoded 127.0.0.1:5000 default, since tests and non-default OSRM setups had no way to override it without passing osrm_url on every call.

Verified: full test suite passes (252 tests, incl. new single-ping and divide-by-zero regression tests), and a full-pipeline run on the 100-ping fixture against a live OSRM server produces byte-for-byte identical output to unmodified main aside from the timing field.